### PR TITLE
Hook up tap devices to bridges

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -23,6 +23,7 @@ Vagrant.configure("2") do |config|
     yum install -y \
       openvpn \
       bridge-utils \
-      vconfig
+      vconfig \
+      net-tools
   SHELL
 end

--- a/cmd/hil-vpn-privop/commands.go
+++ b/cmd/hil-vpn-privop/commands.go
@@ -16,7 +16,7 @@ var keyFileRe = regexp.MustCompile("^hil-vpn-([-_a-zA-Z0-9]+).key$")
 
 // Implement the 'create' subcommand.
 func createCmd(vpnName string, vlanNo, portNo uint16) string {
-	cfg, err := NewOpenVpnConfig(vpnName, portNo)
+	cfg, err := NewOpenVpnConfig(vpnName, vlanNo, portNo)
 	chkfatal("Generating openvpn config:", err)
 	chkfatal("Saving openvpn config:", cfg.Save())
 	return cfg.Key

--- a/cmd/hil-vpn-privop/main.go
+++ b/cmd/hil-vpn-privop/main.go
@@ -112,7 +112,6 @@ func main() {
 		vlanNo := checkVlan(os.Args[3])
 		portNo := checkPort(os.Args[4])
 		fmt.Print(createCmd(vpnName, vlanNo, portNo))
-		fmt.Fprintln(os.Stderr, "TODO: actually set up the VPN.")
 	case "start":
 		checkNumArgs(1)
 		vpnName := checkVpnName(os.Args[2])

--- a/cmd/hil-vpn-privop/openvpn-conf.go
+++ b/cmd/hil-vpn-privop/openvpn-conf.go
@@ -24,6 +24,12 @@ cipher AES-256-CBC
 
 lport {{ .Port }}
 
+# FIXME: this needs to be an absolute path; need to decide where to actually put
+# the script.
+up "hil-vpn-hook-up {{ .Vlan }}"
+# Needed to permit the above to actually run:
+script-security 2
+
 user nobody
 group nobody
 `))
@@ -32,6 +38,7 @@ type OpenVpnCfg struct {
 	Name string
 	Key  string
 	Port uint16
+	Vlan uint16
 }
 
 // Get the path to the file in which to store the openvpn config for the
@@ -109,7 +116,7 @@ func (cfg OpenVpnCfg) NewInterfaceName() string {
 }
 
 // Generate a new openvpn config (including a static key).
-func NewOpenVpnConfig(name string, port uint16) (*OpenVpnCfg, error) {
+func NewOpenVpnConfig(name string, vlan, port uint16) (*OpenVpnCfg, error) {
 	cmd := exec.Command("openvpn", "--genkey", "--secret", "/dev/fd/1")
 	output, err := cmd.Output()
 	if err != nil {
@@ -118,6 +125,7 @@ func NewOpenVpnConfig(name string, port uint16) (*OpenVpnCfg, error) {
 	return &OpenVpnCfg{
 		Name: name,
 		Port: port,
+		Vlan: vlan,
 		Key:  string(output),
 	}, nil
 }

--- a/cmd/hil-vpn-privop/openvpn-conf.go
+++ b/cmd/hil-vpn-privop/openvpn-conf.go
@@ -24,9 +24,7 @@ cipher AES-256-CBC
 
 lport {{ .Port }}
 
-# FIXME: this needs to be an absolute path; need to decide where to actually put
-# the script.
-up "hil-vpn-hook-up {{ .Vlan }}"
+up "/usr/local/libexec/hil-vpn-hook-up {{ .Vlan }}"
 # Needed to permit the above to actually run:
 script-security 2
 

--- a/create-bridges.sh
+++ b/create-bridges.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env sh
+#
+# Set up a range of bridges and corresponding vlan nics. This is more-or less
+# the same thing as the create_bridges script in HIL.
+#
+# Usage: $0 first-vlan last-vlan trunk-nic
+set -e
+
+start=${1?}
+stop=${2?}
+trunk_nic=${3?}
+
+for i in `seq $start $stop`; do
+	bridge=br-vlan${i}
+	vlan_nic=${trunk_nic}.${i}
+	brctl addbr $bridge
+	vconfig add $trunk_nic $i
+	brctl addif $bridge $vlan_nic
+	ifconfig $bridge up promisc
+	ifconfig $vlan_nic up promisc
+done

--- a/openvpn-hooks/hil-vpn-hook-up
+++ b/openvpn-hooks/hil-vpn-hook-up
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -e
+
+vlan="${1?}"
+
+/sbin/brctl addif "br-vlan${vlan?}" "${dev?}"


### PR DESCRIPTION
This is a bit more of a draft than the others. This adds a hook to the openvpn configs to attach the tap devices to the appropriate bridges, and adds an adaptation of the create-bridges script to the repo.

On the latter point, we may want to just keep using the HIL version, since that understand's HIL's allocation scheme.

After this, what's left is:

1. I want to do some proper integration testing of all this; I've been testing the stuff that touches the system manually with vagrant, but that won't scale in the long term.
2. We need to actually put auth(z) stuff in place.
3. Sensible HTTP server config stuff, probably shared with obmd.
4. Cohesive user-facing documentation.

...once that's all in place I think this is actually ready to go.