### PR TITLE
Correctly restore state of allocated vpns on startup.

### DIFF
--- a/cmd/hil-vpnd/api.go
+++ b/cmd/hil-vpnd/api.go
@@ -146,8 +146,3 @@ func makeHandler(privops PrivOps, states *VpnStates) http.Handler {
 
 	return r
 }
-
-// format the vpn name as we will pass it to PrivOps.
-func makeVpnName(id UniqueId, port uint16) string {
-	return fmt.Sprintf("hil_vpn_id_%x_port_%d", id, port)
-}

--- a/cmd/hil-vpnd/api_test.go
+++ b/cmd/hil-vpnd/api_test.go
@@ -19,7 +19,7 @@ func initTestServer() (*MockPrivOps, *httptest.Server) {
 	states := newStates(config{
 		MinPort: 5000,
 		MaxPort: 5009,
-	})
+	}, []string{})
 
 	handler := makeHandler(ops, states)
 	server := httptest.NewServer(handler)

--- a/cmd/hil-vpnd/api_test.go
+++ b/cmd/hil-vpnd/api_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"strconv"
 	"testing"
 )
 
@@ -14,8 +15,7 @@ import (
 //
 // The server's VpnStates will be populated with available ports in the range
 // 5000-5009.
-func initTestServer() (*MockPrivOps, *httptest.Server) {
-	ops := NewMockPrivOps()
+func initTestServer(ops *MockPrivOps) *httptest.Server {
 	daemon, err := newDaemon(config{
 		MinPort: 5000,
 		MaxPort: 5009,
@@ -26,18 +26,24 @@ func initTestServer() (*MockPrivOps, *httptest.Server) {
 
 	server := httptest.NewServer(daemon.handler)
 
-	return ops, server
+	return server
 }
 
 // Test basic successful vpn creation.
 func TestCreate(t *testing.T) {
-	ops, server := initTestServer()
+	ops := NewMockPrivOps()
+	server := initTestServer(ops)
 	defer server.Close()
+	successfullyCreateVpn(t, 232, ops, server)
+}
 
+// Helper for TestCreate, also used as setup elsewhere.
+func successfullyCreateVpn(t *testing.T, vlanNo uint16, ops *MockPrivOps, server *httptest.Server) {
 	client := server.Client()
+	vlanStr := strconv.Itoa(int(vlanNo))
 	resp, err := client.Post(server.URL+"/vpns/new", "application/json", bytes.NewBufferString(`
 		{
-			"vlan": 232
+			"vlan": `+vlanStr+`
 		}
 	`))
 	if err != nil {
@@ -56,9 +62,9 @@ func TestCreate(t *testing.T) {
 	if !ok {
 		t.Fatalf("API request returned success, but vpn %s does not exist.", results.Id)
 	}
-	if vpn.vlanNo != 232 {
-		t.Fatalf("Created VPN does not have the expected vlan; should be 232 but is %d.",
-			vpn.vlanNo)
+	if vpn.vlanNo != vlanNo {
+		t.Fatalf("Created VPN does not have the expected vlan; should be %d but is %d.",
+			vlanNo, vpn.vlanNo)
 	}
 	if vpn.key != results.Key {
 		t.Fatalf("Returned key disagrees with stored key; %v vs %v", results.Key, vpn.key)
@@ -72,11 +78,54 @@ func TestCreate(t *testing.T) {
 	}
 }
 
+// Test that starting up a server when a vpn already exists detects the vpn.
+func TestCreateRestore(t *testing.T) {
+	// We create a vpn, then shut down the server...
+	ops := NewMockPrivOps()
+	server := initTestServer(ops)
+	successfullyCreateVpn(t, 232, ops, server)
+	server.Close()
+
+	// ...then start it back up again, and create another one.
+	server = initTestServer(ops)
+	defer server.Close()
+	client := server.Client()
+	resp, err := client.Post(server.URL+"/vpns/new", "application/json", bytes.NewBufferString(`
+		{
+			"vlan": 300
+		}
+	`))
+	if err != nil {
+		t.Fatal("Making request:", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("Unexpected status code: %d", resp.StatusCode)
+	}
+	var results CreateVpnResp
+	err = json.NewDecoder(resp.Body).Decode(&results)
+	if err != nil {
+		t.Fatal("Decoding response body:", err)
+	}
+
+	// now check that we have two vpns, and they have different ports.
+	if len(ops.vpns) != 2 {
+		t.Fatalf("There should be 2 vpns, but there are only %d.", len(ops.vpns))
+	}
+	vpns := []*vpnInfo{}
+	for _, v := range ops.vpns {
+		vpns = append(vpns, v)
+	}
+	if vpns[0].portNo == vpns[1].portNo {
+		t.Fatalf("Both vpns got the same port number (%d).", vpns[0].portNo)
+	}
+
+}
+
 // Test expected failures creating vpns
 func TestCreateFail(t *testing.T) {
 	badVlans := []uint16{0, 4095, 4096, 10000}
-
-	ops, server := initTestServer()
+	ops := NewMockPrivOps()
+	server := initTestServer(ops)
 	defer server.Close()
 	client := server.Client()
 	for _, vlanId := range badVlans {
@@ -106,7 +155,8 @@ func expectedVpnName(resp CreateVpnResp) string {
 
 // Test deleting vpns
 func TestDelete(t *testing.T) {
-	ops, server := initTestServer()
+	ops := NewMockPrivOps()
+	server := initTestServer(ops)
 	defer server.Close()
 	client := server.Client()
 
@@ -148,4 +198,10 @@ func TestDelete(t *testing.T) {
 	if ok {
 		t.Fatal("VPN not deleted")
 	}
+}
+
+func TestRestore(t *testing.T) {
+	ops := NewMockPrivOps()
+	server := initTestServer(ops)
+	server.Close()
 }

--- a/cmd/hil-vpnd/api_test.go
+++ b/cmd/hil-vpnd/api_test.go
@@ -16,13 +16,15 @@ import (
 // 5000-5009.
 func initTestServer() (*MockPrivOps, *httptest.Server) {
 	ops := NewMockPrivOps()
-	states := newStates(config{
+	daemon, err := newDaemon(config{
 		MinPort: 5000,
 		MaxPort: 5009,
-	}, []string{})
+	}, ops)
+	if err != nil {
+		panic(err)
+	}
 
-	handler := makeHandler(ops, states)
-	server := httptest.NewServer(handler)
+	server := httptest.NewServer(daemon.handler)
 
 	return ops, server
 }

--- a/cmd/hil-vpnd/api_test.go
+++ b/cmd/hil-vpnd/api_test.go
@@ -16,11 +16,10 @@ import (
 // 5000-5009.
 func initTestServer() (*MockPrivOps, *httptest.Server) {
 	ops := NewMockPrivOps()
-	states := newStates()
-
-	for i := 0; i < 10; i++ {
-		states.FreePorts = append(states.FreePorts, uint16(5000+i))
-	}
+	states := newStates(config{
+		MinPort: 5000,
+		MaxPort: 5009,
+	})
 
 	handler := makeHandler(ops, states)
 	server := httptest.NewServer(handler)

--- a/cmd/hil-vpnd/daemon.go
+++ b/cmd/hil-vpnd/daemon.go
@@ -1,0 +1,28 @@
+package main
+
+import (
+	"fmt"
+	"net/http"
+)
+
+// A Daemon manages the runtime state and configuration of hil-vpnd.
+type Daemon struct {
+	handler   http.Handler
+	privops   PrivOps
+	vpnStates *VpnStates
+}
+
+// Generate a new daemon using the given config and PrivOps
+func newDaemon(cfg config, privops PrivOps) (*Daemon, error) {
+	vpnNames, err := privops.ListVPNs()
+	if err != nil {
+		return nil, fmt.Errorf("Listing existing vpns: %v", err)
+	}
+	vpnStates := newStates(cfg, vpnNames)
+
+	return &Daemon{
+		handler:   makeHandler(privops, vpnStates),
+		privops:   privops,
+		vpnStates: vpnStates,
+	}, nil
+}

--- a/cmd/hil-vpnd/main.go
+++ b/cmd/hil-vpnd/main.go
@@ -42,9 +42,10 @@ func getConfig() config {
 
 func main() {
 	cfg := getConfig()
-	// TODO: query the state of existent vpns and populate this accordingly:
-	vpnStates := newStates(cfg, []string{})
-
-	http.Handle("/", makeHandler(PrivOpsCmd{}, vpnStates))
+	daemon, err := newDaemon(cfg, PrivOpsCmd{})
+	if err != nil {
+		log.Fatal(err)
+	}
+	http.Handle("/", daemon.handler)
 	panic(httpserver.Run(&cfg.ServerConfig, nil))
 }

--- a/cmd/hil-vpnd/main.go
+++ b/cmd/hil-vpnd/main.go
@@ -43,7 +43,7 @@ func getConfig() config {
 func main() {
 	cfg := getConfig()
 	// TODO: query the state of existent vpns and populate this accordingly:
-	vpnStates := newStates(cfg)
+	vpnStates := newStates(cfg, []string{})
 
 	http.Handle("/", makeHandler(PrivOpsCmd{}, vpnStates))
 	panic(httpserver.Run(&cfg.ServerConfig, nil))

--- a/cmd/hil-vpnd/main.go
+++ b/cmd/hil-vpnd/main.go
@@ -43,10 +43,7 @@ func getConfig() config {
 func main() {
 	cfg := getConfig()
 	// TODO: query the state of existent vpns and populate this accordingly:
-	vpnStates := newStates()
-	for i := cfg.MinPort; i <= cfg.MaxPort; i++ {
-		vpnStates.FreePorts = append(vpnStates.FreePorts, uint16(i))
-	}
+	vpnStates := newStates(cfg)
 
 	http.Handle("/", makeHandler(PrivOpsCmd{}, vpnStates))
 	panic(httpserver.Run(&cfg.ServerConfig, nil))

--- a/cmd/hil-vpnd/privops.go
+++ b/cmd/hil-vpnd/privops.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"os"
 	"os/exec"
 	"strconv"
 	"strings"
@@ -28,7 +29,12 @@ func privOpCmd(args ...string) *exec.Cmd {
 		[]string{staticconfig.Libexecdir + "/hil-vpn-privop"},
 		args...,
 	)
-	return exec.Command("sudo", sudoArgs...)
+	cmd := exec.Command("sudo", sudoArgs...)
+
+	// Pass through stderr; useful for debugging.
+	cmd.Stderr = os.Stderr
+
+	return cmd
 }
 
 func (PrivOpsCmd) CreateVPN(name string, vlanNo uint16, portNo uint16) (string, error) {

--- a/cmd/hil-vpnd/vpnname.go
+++ b/cmd/hil-vpnd/vpnname.go
@@ -1,0 +1,40 @@
+package main
+
+import (
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"regexp"
+	"strconv"
+)
+
+var (
+	vpnNameRegexp = regexp.MustCompile("^hil_vpn_id_([0-9a-f]{32})_port_([0-9]+)$")
+
+	ErrInvalidVpnName = errors.New("Invalid vpn name")
+)
+
+// format the vpn name as we will pass it to PrivOps.
+func makeVpnName(id UniqueId, port uint16) string {
+	return fmt.Sprintf("hil_vpn_id_%x_port_%d", id, port)
+}
+
+func parseVpnName(name string) (id UniqueId, port uint16, err error) {
+	matches := vpnNameRegexp.FindStringSubmatch(name)
+	if len(matches) != 3 {
+		return id, port, ErrInvalidVpnName
+	}
+
+	_, err = hex.Decode(id[:], []byte(matches[1]))
+	if err != nil {
+		return id, port, err
+	}
+
+	port64, err := strconv.ParseUint(matches[2], 10, 16)
+	if err != nil {
+		return id, port, err
+	}
+	port = uint16(port64)
+
+	return id, port, nil
+}

--- a/cmd/hil-vpnd/vpnname_test.go
+++ b/cmd/hil-vpnd/vpnname_test.go
@@ -1,0 +1,23 @@
+package main
+
+import (
+	"testing"
+	"testing/quick"
+)
+
+// Verify that parseVpnName successfully reverses the output of makeVpnName.
+func TestVpnName(t *testing.T) {
+	err := quick.Check(func(id UniqueId, port uint16) bool {
+		newId, newPort, err := parseVpnName(makeVpnName(id, port))
+		ok := err == nil &&
+			newId == id &&
+			newPort == port
+		if !ok {
+			t.Logf("Failed; got: %x %x %v", newId, newPort, err)
+		}
+		return ok
+	}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+}

--- a/cmd/hil-vpnd/vpnstates.go
+++ b/cmd/hil-vpnd/vpnstates.go
@@ -35,7 +35,7 @@ type VpnStates struct {
 // locked).
 
 // Allocate a fresh VpnStates, with `FreePorts` generated based on
-// the config. The `vpnNames` argument should the output of
+// the config. The `vpnNames` argument should be the output of
 // PrivOps.ListVPNs.
 func newStates(cfg config, vpnNames []string) *VpnStates {
 	ret := &VpnStates{

--- a/cmd/hil-vpnd/vpnstates.go
+++ b/cmd/hil-vpnd/vpnstates.go
@@ -34,12 +34,17 @@ type VpnStates struct {
 // methods are not (but may be called when the VpnStates is already
 // locked).
 
-// Allocate an empty VpnStates.
-func newStates() *VpnStates {
-	return &VpnStates{
+// Allocate a fresh VpnStates, with `FreePorts` generated based on
+// the config.
+func newStates(cfg config) *VpnStates {
+	ret := &VpnStates{
 		UsedPorts: map[UniqueId]uint16{},
 		FreePorts: []uint16{},
 	}
+	for i := cfg.MinPort; i <= cfg.MaxPort; i++ {
+		ret.FreePorts = append(ret.FreePorts, uint16(i))
+	}
+	return ret
 }
 
 // Allocate a new vpn. Returns a unique id and a port number.

--- a/cmd/hil-vpnd/vpnstates_test.go
+++ b/cmd/hil-vpnd/vpnstates_test.go
@@ -5,13 +5,10 @@ import (
 )
 
 func TestVpnStates(t *testing.T) {
-	states := newStates()
-	states.FreePorts = []uint16{
-		4000,
-		4001,
-		4002,
-		4003,
-	}
+	states := newStates(config{
+		MinPort: 4000,
+		MaxPort: 4003,
+	})
 
 	vpns := []UniqueId{}
 

--- a/cmd/hil-vpnd/vpnstates_test.go
+++ b/cmd/hil-vpnd/vpnstates_test.go
@@ -8,7 +8,7 @@ func TestVpnStates(t *testing.T) {
 	states := newStates(config{
 		MinPort: 4000,
 		MaxPort: 4003,
-	})
+	}, []string{})
 
 	vpns := []UniqueId{}
 


### PR DESCRIPTION
hil-vpnd now calls `hil-vpn-privop list` on startup to work out what ports have already been allocated.

I *think* the only thing left after this is to add authentication. I would also like to do some proper integration testing before deployment.