### PR TITLE
Add a DESTDIR variable to make packaging easier.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,12 @@
 # 2. hil-vpn doesn't actually use most of these, and probably never will,
 #    but we specify the whole set for the sake of making this orthogonal
 #    to the rest of the code.
+#
+# When using the `install` target, you may also supply a DESTDIR variable
+# to install somewhere other than the actual root filesystem; this is useful
+# for packaging:
+#
+#    make PREFIX=/usr SYSCONFDIR=/etc DESTDIR=... install
 PREFIX         ?= /usr/local
 EXEC_PREFIX    ?= $(PREFIX)
 BINDIR         ?= $(EXEC_PREFIX)/bin
@@ -80,8 +86,8 @@ all:
 	@echo BUILD hil-vpn-privop
 	@cd cmd/hil-vpn-privop ; go build -ldflags "$(GO_LDFLAGS)"
 install:
-	install -Dm755 ./cmd/hil-vpnd/hil-vpnd             $(SBINDIR)/
-	install -Dm755 ./cmd/hil-vpn-privop/hil-vpn-privop $(LIBEXECDIR)/
-	install -Dm755 ./openvpn-hooks/hil-vpn-hook-up     $(LIBEXECDIR)/
+	install -Dm755 ./cmd/hil-vpnd/hil-vpnd             -t $(DESTDIR)$(SBINDIR)/
+	install -Dm755 ./cmd/hil-vpn-privop/hil-vpn-privop -t $(DESTDIR)$(LIBEXECDIR)/
+	install -Dm755 ./openvpn-hooks/hil-vpn-hook-up     -t $(DESTDIR)$(LIBEXECDIR)/
 
 .PHONY: all install

--- a/go.mod
+++ b/go.mod
@@ -1,10 +1,8 @@
 module github.com/CCI-MOC/hil-vpn
 
 require (
-	github.com/CCI-MOC/obmd v0.0.0-20181207223216-8ace7dc47456
+	github.com/CCI-MOC/obmd v0.0.0-20181215225251-2c8b84b9943a
 	github.com/caarlos0/env v3.5.0+incompatible
 	github.com/gorilla/mux v1.6.2
 	golang.org/x/sys v0.0.0-20181011152604-fa43e7bc11ba
 )
-
-replace github.com/CCI-MOC/obmd => ../obmd

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,8 @@ github.com/CCI-MOC/obmd v0.0.0-20181108180920-2d628d0e8fc1 h1:Y28erVFc2hp4klQ/0m
 github.com/CCI-MOC/obmd v0.0.0-20181108180920-2d628d0e8fc1/go.mod h1:HZekg8MxEWCjMMGnKf4tAaX5j5xI9EwUCsc26Tu/YlY=
 github.com/CCI-MOC/obmd v0.0.0-20181207223216-8ace7dc47456 h1:+0cGBCehWsOzSQsUD3kpoq6iieZ/UgYD92fouSbpUBE=
 github.com/CCI-MOC/obmd v0.0.0-20181207223216-8ace7dc47456/go.mod h1:K+fcc2O/SNAaLWfAp7zVpCrEYot0pqFYGzbL0WRBSOI=
+github.com/CCI-MOC/obmd v0.0.0-20181215225251-2c8b84b9943a h1:ZOVtWXbR273+LIAfH07VXT3jBOL4IOQXXjNhCDdIHu4=
+github.com/CCI-MOC/obmd v0.0.0-20181215225251-2c8b84b9943a/go.mod h1:K+fcc2O/SNAaLWfAp7zVpCrEYot0pqFYGzbL0WRBSOI=
 github.com/caarlos0/env v3.5.0+incompatible h1:Yy0UN8o9Wtr/jGHZDpCBLpNrzcFLLM2yixi/rBrKyJs=
 github.com/caarlos0/env v3.5.0+incompatible/go.mod h1:tdCsowwCzMLdkqRYDlHpZCp2UooDD3MspDBjZ2AD02Y=
 github.com/gorilla/mux v1.6.2 h1:Pgr17XVTNXAk3q/r4CpKzC5xBM/qW1uVLV+IhRZpIIk=


### PR DESCRIPTION
See the comments. In addition, we change the calls to install to use
`-t`, which results in creating the directories if they don't exist --
this is useful when used in conjunction with DESTDIR.